### PR TITLE
updates  probability value in documentation for horizontal_flip example

### DIFF
--- a/mkdocs/src/docs/introduction/why_you_need_a_dedicated_library_for_image_augmentation.md
+++ b/mkdocs/src/docs/introduction/why_you_need_a_dedicated_library_for_image_augmentation.md
@@ -70,7 +70,7 @@ Image augmentation libraries allow you to set the required probabilities and the
 
 Usually, you want to apply not a single augmentation, but a set of augmentations with specific parameters such as probability and magnitude of changes. Augmentation libraries allow you to declare such a pipeline in a single place and then use it for image transformation through a unified interface. Some libraries can store and load transformation parameters to formats such as JSON, YAML, etc.
 
-Here is an example definition of an augmentation pipeline. This pipeline will first crop a random 512px x 512px part of the input image. Then with probability 30%, it will randomly change brightness and contrast of that crop. Finally, with probability 30%, it will horizontally flip the resulting image.
+Here is an example definition of an augmentation pipeline. This pipeline will first crop a random 512px x 512px part of the input image. Then with probability 30%, it will randomly change brightness and contrast of that crop. Finally, with probability 50%, it will horizontally flip the resulting image.
 
 ```python
 import albumentations as A


### PR DESCRIPTION
Minor change in documentation. The original text read `Finally, with probability 30%, it will horizontally flip the resulting image.`, but the example code applied Horizontal Flip with 50% probability. So modified the text to `Finally, with probability 50%, it will horizontally flip the resulting image.`