### PR TITLE
Cleaned up docs from unused notebooks

### DIFF
--- a/docs/src/docs/examples/index.md
+++ b/docs/src/docs/examples/index.md
@@ -20,10 +20,7 @@
 - [Showcase. Cool augmentation examples on diverse set of images from various real-world tasks.](showcase/)
 - [How to save and load transforms to HuggingFace Hub.](example_hfhub/)
 
-## Examples of how to use Albumentations with different deep learning frameworks
+## Examples of how to use Albumentations with PyTorch
 
-- PyTorch
-  - [PyTorch and Albumentations for image classification](pytorch_classification/)
-  - [PyTorch and Albumentations for semantic segmentation](pytorch_semantic_segmentation/)
-- TensorFlow 2
-  - [Using Albumentations with Tensorflow](tensorflow-example/)
+- [PyTorch and Albumentations for image classification](pytorch_classification/)
+- [PyTorch and Albumentations for semantic segmentation](pytorch_semantic_segmentation/)

--- a/docs/src/docs/getting_started/image_augmentation.md
+++ b/docs/src/docs/getting_started/image_augmentation.md
@@ -32,7 +32,7 @@ transform = A.Compose([
     A.RandomCrop(width=256, height=256),
     A.HorizontalFlip(p=0.5),
     A.RandomBrightnessContrast(p=0.2),
-])
+], seed=137, strict=True)
 
 ```
 
@@ -63,11 +63,8 @@ import cv2
 To read an image with OpenCV
 
 ```python
-
-image = cv2.imread("/path/to/image.jpg")
-image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+image = cv2.imread("/path/to/image.jpg", cv2.IMREAD_COLOR_RGB)
 ```
-Note the usage of `cv2.cvtColor`. [For historical reasons](https://www.learnopencv.com/why-does-opencv-use-bgr-color-format/), OpenCV reads an image in BGR format (so color channels of the image have the following order: Blue, Green, Red). Albumentations uses the most common and popular RGB image format. So when using OpenCV, we need to convert the image format to RGB explicitly.
 
 !!! note ""
     Besides OpenCV, you can use other image processing libraries.
@@ -133,6 +130,5 @@ another_transformed_image = transform(image=another_image)["image"]
 
 ## Examples
 - [Defining a simple augmentation pipeline for image augmentation](../../examples/example/)
-- [Working with non-8-bit images](../../examples/example_16_bit_tiff/)
 - [Weather augmentations in Albumentations](../../examples/example_weather_transforms/)
 - [Showcase. Cool augmentation examples on diverse set of images from various real-world tasks.](../../examples/showcase/)

--- a/docs/src/docs/index.md
+++ b/docs/src/docs/index.md
@@ -49,7 +49,6 @@ You can also visit [explore.albumentations.ai](https://explore.albumentations.ai
 ## Framework Integration
 
 - [PyTorch](examples/pytorch_classification/)
-- [TensorFlow](examples/tensorflow-example/)
 - [HuggingFace](integrations/huggingface/)
 - [Roboflow](integrations/roboflow/train-rt-detr-on-custom-dataset-with-transformers.md)
 - [Voxel51](integrations/fiftyone.md)
@@ -84,7 +83,6 @@ You can also visit [explore.albumentations.ai](https://explore.albumentations.ai
 
 - [PyTorch and Albumentations for image classification](examples/pytorch_classification/)
 - [PyTorch and Albumentations for semantic segmentation](examples/pytorch_semantic_segmentation/)
-- [Using Albumentations with Tensorflow](examples/tensorflow-example/)
 
 ## External resources
 


### PR DESCRIPTION
## Summary by Sourcery

Remove TensorFlow examples and add `strict` and `seed` parameters to the Compose transform.

Documentation:
- Removed TensorFlow examples from the documentation.
- Added `strict` and `seed` parameters to the Compose transform.
- Updated the OpenCV image reading example to use `cv2.IMREAD_COLOR_RGB`.